### PR TITLE
Fixed Unable to preventDefault inside passive event listener

### DIFF
--- a/src/Agile.vue
+++ b/src/Agile.vue
@@ -346,7 +346,9 @@
 
             disableScroll () {
                 document.ontouchmove = function (e) {
-                    e.preventDefault()
+                    if (!e.touches) {
+                        e.preventDefault()
+                    }
                 }
             },
 


### PR DESCRIPTION
Fixed chrome mobile ontouchmove preventDefault bug.
Detail: https://www.chromestatus.com/features/5093566007214080

![image 2018-12-26 at 3 34 03 pm](https://user-images.githubusercontent.com/1588236/50446047-c7acb280-0923-11e9-92bd-8a6a878e1ad7.png)
