### PR TITLE
form component on slide now worked

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import VueAgile from './Agile'
+import VueAgile from './Agile.vue'
 
 const install = (Vue) => {
 	Vue.component('agile', VueAgile)

--- a/src/mixins/handlers.js
+++ b/src/mixins/handlers.js
@@ -4,7 +4,6 @@
 const mixin = {
 	methods: {
 		handleMouseDown (e) {
-
 			this.mouseDown = true
 			this.dragStartX = ('ontouchstart' in window) ? e.touches[0].clientX : e.clientX
 			this.dragStartY = ('ontouchstart' in window) ? e.touches[0].clientY : e.clientY

--- a/src/mixins/handlers.js
+++ b/src/mixins/handlers.js
@@ -4,9 +4,7 @@
 const mixin = {
 	methods: {
 		handleMouseDown (e) {
-			if (!e.touches) {
-				e.preventDefault()
-			}
+
 			this.mouseDown = true
 			this.dragStartX = ('ontouchstart' in window) ? e.touches[0].clientX : e.clientX
 			this.dragStartY = ('ontouchstart' in window) ? e.touches[0].clientY : e.clientY


### PR DESCRIPTION
Hello. I use your vue-agile plugin, and I needs to put form inputs on slider. Because of e.preventDefault() in handleMouseDown input fields don't get a focus. I'll remove e.preventDefault()and it is worked. 

Add extension .vue in index.js because webpack gives an error "module has not found"