### PR TITLE
Delay Slide Change

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Every first-level child of `<agile>` is a new slide. You also can group them ins
 | autoplay | boolean | `false` | Enable autoplay |
 | autoplaySpeed | integer (ms) | `3000` | Autoplay interval in milliseconds | 
 | centerMode | boolean | `false` | Enable centered view when `slidesToShow` > `1` |
+| changeDelay | integer | `0` | Insert a delay when switching slides. Useful for fade: `true` |
 | dots | boolean | `true` | Enable dot indicators/pagination |
 | fade | boolean | `false` | Enable fade effect |
 | infinite | boolean | `true` | Infinite loop sliding | 

--- a/src/mixins/preparations.js
+++ b/src/mixins/preparations.js
@@ -59,7 +59,7 @@ const mixin = {
 			}
 
 			// Add active & current class for current slide
-			this.slides[this.currentSlide].classList.add('agile__slide--active')
+			setTimeout(() => this.slides[this.currentSlide].classList.add('agile__slide--active'), this.changeDelay)
 
 			let start = (this.clonedSlides) ? this.slidesCount + this.currentSlide : this.currentSlide
 

--- a/src/mixins/props.js
+++ b/src/mixins/props.js
@@ -51,7 +51,15 @@ const mixin = {
 			default: '15%'
 		},
 
-		/**
+    /**
+     * Slide change delay in milliseconds
+     */
+    changeDelay: {
+      type: Number,
+      default: 0
+    },
+
+    /**
 		 * Enable dot indicators/pagination
 		 */
 		dots: {
@@ -67,7 +75,7 @@ const mixin = {
 			default: false
 		},
 
-		/**
+    /**
 		 * Infinite loop sliding
 		 */
 		infinite: {


### PR DESCRIPTION
I wanted to have a small delay between slides changing when using the fade transition. The goal was to be able to see the slide fade out and the next one fade in. The current implementation will show the next slide almost immediately even with a slow transition speed. This optional parameter will default to the existing behavior but allow for a delay when adding active class.