### PR TITLE
Update main entry to use common.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build-bundle": "vue-cli-service build --target lib --name VueAgile ./src/Agile.vue && rm dist/demo.html",
     "build-docs": "vue-cli-service build ./demo/main.js --dest ./docs --modern"
   },
-  "main": "src/index.js",
+  "main": "dist/VueAgile.common.js",
   "unpkg": "dist/VueAgile.umd.min.js",
   "files": [
     "dist/*",


### PR DESCRIPTION
fix #172 

We need to use the common version transpiled by babel.