### PR TITLE
Removing Unable to preventDefault error

### DIFF
--- a/src/mixins/methods.js
+++ b/src/mixins/methods.js
@@ -14,7 +14,7 @@ const mixin = {
 		},
 
 		disableScroll () {
-			document.ontouchmove = (e) => e.preventDefault()
+			document.addEventListener( 'touchmove', e => e.preventDefault(), { passive: false } )
 		},
 
 		enableScroll () {


### PR DESCRIPTION
When trying to switch slides with your mouse, for every "drag" with the cursor you get in the console [Intervention] Unable to preventDefault inside passive event listener due to target being treated as passive.