### PR TITLE
Changed cloned slides to v-if t prevent logic execution

### DIFF
--- a/src/Agile.vue
+++ b/src/Agile.vue
@@ -16,7 +16,7 @@
 				@mouseout="handleMouseOut('track')"
 			>
 				<div
-					v-show="slidesCloned"
+					v-if="slidesCloned"
 					ref="slidesClonedBefore"
 					class="agile__slides agile__slides--cloned"
 				>
@@ -31,7 +31,7 @@
 				</div>
 
 				<div
-					v-show="slidesCloned"
+					v-if="slidesCloned"
 					ref="slidesClonedAfter"
 					class="agile__slides agile__slides--cloned"
 				>


### PR DESCRIPTION
Changed v-show to v-if for the cloned slides tracks to prevent unnecessary executed/mounted components within the slides.