### PR TITLE
Rename `beforeDestroy` to `beforeUnmount` in order to improve Vue 3 compatibility

### DIFF
--- a/src/Agile.vue
+++ b/src/Agile.vue
@@ -211,7 +211,7 @@
 			this.reload()
 		},
 
-		beforeDestroy () {
+		beforeUnmount () {
 			window.removeEventListener('resize', this.getWidth)
 
 			this.$refs.track.removeEventListener('touchstart', this.handleMouseDown)


### PR DESCRIPTION
Fix the `BeforeDestroy` has been renamed to `beforeUnmount` warning in Vue 3.