### PR TITLE
Define emits in Agile component

### DIFF
--- a/src/Agile.vue
+++ b/src/Agile.vue
@@ -116,6 +116,8 @@
 		name: 'Agile',
 
 		mixins: [handlers, helpers, methods, preparations, settings, throttle, watchers],
+		
+		emits: ["before-change", "after-change", "breakpoint"],
 
 		data () {
 			return {


### PR DESCRIPTION
 in order to get rid of Extraneous non-emits event listeners  warnings in Vue 3