### PR TITLE
Fix: destroy don't triggered in Vue 2

### DIFF
--- a/src/Agile.vue
+++ b/src/Agile.vue
@@ -163,6 +163,11 @@
       this.reload()
     },
 
+    // Vue 2
+    beforeDestroy() {
+			this.destroy()
+		},
+
     // Vue 3
     beforeUnmount () {
       this.destroy()


### PR DESCRIPTION
Hey @lukaszflorczak you missed the "vue 2" part of my MR (https://github.com/lukaszflorczak/vue-agile/pull/216/files#diff-08eda04003f9354401feadd60a810eec56c70617a1e28cfb8ecf9ff5a7605596R220) or lost it in the merge.

Keep beforeDestroy-method makes it compatible with vue 2 as well as vue 3!